### PR TITLE
Hosting/docker image Pull Request

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:21-alpine3.19
+RUN mkdir /home/hisv
+WORKDIR /home/hisv
+COPY yarn.lock package.json ./
+RUN yarn install
+COPY . /home/hisv/ 
+EXPOSE 5173
+CMD ["yarn", "dev", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ WORKDIR /home/hisv
 COPY yarn.lock package.json ./
 RUN yarn install
 COPY . /home/hisv/ 
-EXPOSE 5173
-CMD ["yarn", "dev", "--host", "0.0.0.0"]
+EXPOSE 3000
+RUN yarn build
+CMD ["yarn", "start", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  app:
+    image: fabiuni/teamprojekt
+    volumes:
+      - ./public:home/hisv/public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: '3'
 services:
-  app:
+  hisv:
     image: fabiuni/teamprojekt
+    ports:
+      - "3000:3000"
     volumes:
-      - ./public:home/hisv/public
+      - ./public:/home/hisv/public


### PR DESCRIPTION
## Changes made
A docker file to generate a docker image was created from the node:alpine image and a docker-compose.yml file was created to enable storing the splats outside of the docker image to limit image size.

## How to test
Copying the docker-compose.yml file into a folder with a ``public`` subfolder that holds the splats you want to see should be enough. The image is stored on [Dockerhub](https://hub.docker.com/repository/docker/fabiuni/teamprojekt/general).

## Problems
The image is still rather large, even compressed (867.85 MB), partly due to still containing the test shoe. In the future the shoe could be removed, though for now it is useful for testing.

This solves #58 