### PR TITLE
adds controls info popup

### DIFF
--- a/app/components/controlsInfo.tsx
+++ b/app/components/controlsInfo.tsx
@@ -1,0 +1,27 @@
+import { useState} from 'react'
+import '~/styles/controlsInfo.css'
+
+// using https://github.com/shhdharmen/keyboard-css "keyboard-css" for keyboard keys
+
+function ControlsInfoPopup() {
+  const [popupStatus, setPopupStatus] = useState(true);
+
+  return popupStatus ? (
+    <div className="controlsInfoPopup">
+      <link rel="stylesheet" href="https://unpkg.com/keyboard-css@1.2.4/dist/css/main.min.css" />
+      <div className="controlsInfo">
+        <button 
+          className="close-btn" 
+          onClick={() => setPopupStatus(false)}>
+          got it!
+        </button>
+        <span className="controls-title">Controls:</span> <br />
+        <span className="mouse-icon">🖱️</span> to look around <br />
+        <kbd className="kbc-button-sm">esc</kbd> to regain normal mouse controls<br />
+        <kbd className="kbc-button-sm">W</kbd><kbd class="kbc-button-sm">A</kbd><kbd class="kbc-button-sm">S</kbd><kbd class="kbc-button-sm">D</kbd> to move around
+      </div>
+    </div>
+  ) : "";
+}
+
+export default ControlsInfoPopup

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,9 +1,14 @@
 import CanvasLayer from '~/components/CanvasLayer';
+import ControlsInfoPopup from '~/components/controlsInfo'
 
 export default function Index() {
   return (
     <>
       <CanvasLayer />
+
+      <ControlsInfoPopup>
+      </ControlsInfoPopup>
+
       <h1 className="fixed top-12 left-12 text-xl text-white">
         Hyperrealistic Indoor Street View <br /> Exercise
       </h1>

--- a/app/styles/controlsInfo.css
+++ b/app/styles/controlsInfo.css
@@ -1,0 +1,49 @@
+.controlsInfoPopup {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.75);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.controlsInfo {
+  position: relative;
+  padding: 32px;
+  width: 100%;
+  max-width: 640px;
+  color: #FFFFFF;
+  background-color: #181C20;
+  box-shadow: 0 4px 8px #000000;
+  border-radius: 5px;
+  line-height:40px;
+}
+
+.close-btn {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  cursor: pointer;
+  font-size: 16px;
+
+  width: 60px;
+  height: 40px;
+  background-color: #303030;
+  text-align: center;
+  border-radius: 5px;
+}
+
+.mouse-icon {
+  font-size: 40px;
+}
+
+.controls-title {
+  font-size: 32px;
+}
+
+.close-btn:hover {
+  background-color: #5a5a5a;
+}


### PR DESCRIPTION
closes #91 
adds a simple popup which explains the controls when accessing the site. easy to expand if needed.
cant be reopened currently, isnt really needed though as the controls are pretty self explanatory once seen
